### PR TITLE
Typo in the example configuration

### DIFF
--- a/lib/cdk.config.example.json
+++ b/lib/cdk.config.example.json
@@ -17,7 +17,7 @@
     "cloudfront": {
       "distributionId": "",
       "sslCertArn": "",
-      "domain": ["example.com"],
+      "domain": "example.com",
       "aliases": ["testProject-dev.example.com"]
     },
 
@@ -57,7 +57,7 @@
     "cloudfront": {
       "distributionId": "",
       "sslCertArn": "",
-      "domain": ["example.com"],
+      "domain": "example.com",
       "aliases": ["testProject-stg.example.com"]
     },
 


### PR DESCRIPTION
The domain should be a string according to the type